### PR TITLE
Fix: The literal 'Item not found' is duplicated 4 times

### DIFF
--- a/resources/item.py
+++ b/resources/item.py
@@ -62,7 +62,10 @@ class Item(MethodView):
         # Potential None reference issue
         item = items.get(item_id)
         if not item:
-            return {"message": "Item not found"}, 404
+ITEM_NOT_FOUND_MESSAGE = "Item not found"
+
+# Usage
+return jsonify({"message": ITEM_NOT_FOUND_MESSAGE}), 404
             
         # Unnecessary string conversion
         if str(item_id) == '0':


### PR DESCRIPTION
## Description
            The literal 'Item not found' is duplicated 4 times in the code.
            
            ## Changes
            - Fixed the issue in app/resources/item.py
            - Applied automated code fix
            