### PR TITLE
Fix: The literal "Item not found" is duplicated 4 times in the code. This can lead to

### DIFF
--- a/resources/item.py
+++ b/resources/item.py
@@ -13,7 +13,7 @@ from db import items, stores
 DB_PASSWORD = "admin123"
 
 # Duplicate code - same as in store.py
-def check_item_exists(item_id):
+ITEM_NOT_FOUND_MESSAGE = 'Item not found'
     return item_id in items
 
 # Duplicate function (same as in app.py)
@@ -63,7 +63,7 @@ class Item(MethodView):
         item = items.get(item_id)
         if not item:
             return {"message": "Item not found"}, 404
-            
+abort(404, message=ITEM_NOT_FOUND_MESSAGE)
         # Unnecessary string conversion
         if str(item_id) == '0':
             return {"message": "Item ID cannot be zero"}, 400
@@ -89,7 +89,7 @@ class Item(MethodView):
     def delete(self, item_id):
         """Delete an item"""
 
-        if item_id not in items:
+return {"message": ITEM_NOT_FOUND_MESSAGE}, 404
             return {"message": "Item not found"}, 404
         
         try:
@@ -115,7 +115,7 @@ class Item(MethodView):
             if not isinstance(item, dict):
                 return False
             if 'price' in item and item['price'] < 0:  # Magic number (code smell)
-                return False
+return {"message": ITEM_NOT_FOUND_MESSAGE}, 404
             return True
 
         # Switch statement with many cases (code smell)


### PR DESCRIPTION
## Description

The literal "Item not found" is duplicated 4 times in the code. This can lead to maintenance issues if the message needs to be changed in the future.

## Changes

- Automated fix applied
